### PR TITLE
[miio] Add temperature value to chuangmi.plug.v1

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/resources/database/chuangmi.plug.v1.json
+++ b/bundles/org.openhab.binding.miio/src/main/resources/database/chuangmi.plug.v1.json
@@ -30,6 +30,15 @@
 						"parameterType": "ONOFFPARA"
 					}
 				]
+			},
+			{
+				"property": "temperature",
+				"friendlyName": "Temperature",
+				"channel": "temperature",
+				"type": "Number",
+				"refresh": true,
+				"ChannelGroup": "",
+				"actions": []
 			}
 		]
 	}


### PR DESCRIPTION
[miio] Add temperature value to chuangmi.plug.v1

I see in other projects this plug does also support temperature:
https://github.com/syssi/xiaomiplug/blob/develop/README.md#xiaomi-chuangmi-plug-v1
https://github.com/rytilahti/python-miio/blob/master/miio/chuangmi_plug.py#L23